### PR TITLE
Allow pressing the enter key to select a location while searching in the autocomplete field

### DIFF
--- a/src/resources/views/crud/fields/google_map.blade.php
+++ b/src/resources/views/crud/fields/google_map.blade.php
@@ -194,6 +194,13 @@
                         $field.val(JSON.stringify(data));
 
                     }
+                    
+                    element.keydown(function(e) {
+                        if ($('.pac-container').is(':visible') && e.keyCode == 13) {
+                            e.preventDefault();
+                            return false;
+                        }
+                    });
                 } catch (e) {
                     console.log(e);
                 }


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

While choosing an option from the autocomplete field, pressing enter would submit the form

### AFTER - What is happening after this PR?

Now it just selects the option from the autocomplete field. 

I hope it helps!